### PR TITLE
Refactor: Improve Desktop WebView loading and stability

### DIFF
--- a/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
+++ b/webview/src/commonMain/kotlin/com/multiplatform/webview/web/WebView.kt
@@ -83,9 +83,6 @@ fun WebView(
     webView?.let { wv ->
         LaunchedEffect(wv, navigator) {
             with(navigator) {
-                KLogger.d {
-                    "wv.handleNavigationEvents()"
-                }
                 wv.handleNavigationEvents()
             }
         }
@@ -93,37 +90,7 @@ fun WebView(
         // Handle content loading for all platforms
         LaunchedEffect(wv, state) {
             snapshotFlow { state.content }.collect { content ->
-                when (content) {
-                    is WebContent.Url -> {
-                        state.lastLoadedUrl = content.url
-                        wv.loadUrl(content.url, content.additionalHttpHeaders)
-                    }
-
-                    is WebContent.Data -> {
-                        wv.loadHtml(
-                            content.data,
-                            content.baseUrl,
-                            content.mimeType,
-                            content.encoding,
-                            content.historyUrl,
-                        )
-                    }
-
-                    is WebContent.File -> {
-                        wv.loadHtmlFile(content.fileName, content.readType)
-                    }
-
-                    is WebContent.Post -> {
-                        wv.postUrl(
-                            content.url,
-                            content.postData,
-                        )
-                    }
-
-                    is WebContent.NavigatorOnly -> {
-                        // NO-OP
-                    }
-                }
+                wv.loadContent(content)
             }
         }
 
@@ -160,9 +127,6 @@ fun WebView(
 
     DisposableEffect(Unit) {
         onDispose {
-            KLogger.d {
-                "WebView DisposableEffect"
-            }
             webViewJsBridge?.clear()
         }
     }

--- a/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/DesktopWebView.kt
+++ b/webview/src/desktopMain/kotlin/com/multiplatform/webview/web/DesktopWebView.kt
@@ -75,6 +75,7 @@ class DesktopWebView(
                 webView.loadHtml(html, baseUrl ?: KCEFBrowser.BLANK_URI)
             } catch (e: Exception) {
                 KLogger.e { "DesktopWebView loadHtml error: ${e.message}" }
+                e.printStackTrace()
             }
         } else {
             KLogger.e { "DesktopWebView loadHtml: HTML content is null" }
@@ -127,7 +128,7 @@ class DesktopWebView(
                         }
                     }
 
-                    delay(200)
+                    delay(500)
                     webView.loadURL("file://${outFile.absolutePath}")
                 }
 
@@ -150,19 +151,19 @@ class DesktopWebView(
                     for (entry in jarFile.entries()) {
                         if (entry.name.startsWith(pathInJar.substringBeforeLast("/")) && !entry.isDirectory) {
                             val file =
-                                java.io.File(tempDirectory, entry.name.substringAfterLast("/"))
+                                File(tempDirectory, entry.name.substringAfterLast("/"))
                             file.outputStream().use { output ->
                                 jarFile.getInputStream(entry).copyTo(output)
                             }
                         }
                     }
 
-                    val htmlFile = java.io.File(tempDirectory, pathInJar.substringAfterLast("/"))
+                    val htmlFile = File(tempDirectory, pathInJar.substringAfterLast("/"))
                     if (!htmlFile.exists()) {
                         throw Exception("Extracted HTML file not found: ${htmlFile.absolutePath}")
                     }
 
-                    delay(200)
+                    delay(500)
                     webView.loadURL("file://${htmlFile.absolutePath}")
                 }
             }


### PR DESCRIPTION
This commit introduces several improvements to the desktop WebView implementation:

- **Increased delay for file loading:** The delay before loading local HTML files (both from assets and Compose resources) has been increased from 200ms to 500ms. This provides more time for file extraction and setup, potentially improving reliability.
- **Error handling for HTML loading:** Added `e.printStackTrace()` in the `catch` block of `DesktopWebView.loadHtml` for better debugging of HTML loading errors.
- **Unified content loading:** Refactored `WebView.kt` to use a common `wv.loadContent(content)` call within the `LaunchedEffect` for all content types, simplifying the logic.
- **Refined Desktop WebView initialization:**
    - The `KCEFBrowser` instance is now recreated if `state.content` changes, ensuring the browser is correctly initialized for different content types (e.g., when switching from URL to File).
    - `WebViewFactoryParam` for `WebContent.File` now passes `param.requestContext` to `createBrowser`.
    - `state.webView` and `webViewJsBridge?.webView` are now set within a `LaunchedEffect` dependent on `desktopWebView` to ensure they are assigned after the `DesktopWebView` instance is fully created.
- **Removed verbose logging:** Removed some KLogger debug statements related to navigation events and disposal.
- **Standardized File import:** Changed `java.io.File` to `File` for consistency.