### PR TITLE
Fix: Use configurable jsBridgeName in WasmJs and update version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ android.minSdk=21
 #Versions
 GROUP=io.github.kevinnzou
 POM_ARTIFACT_ID=compose-webview-multiplatform
-VERSION_NAME=2.0.2
+VERSION_NAME=2.0.3
 POM_NAME=Compose WebView Multiplatform
 POM_INCEPTION_YEAR=2023
 POM_DESCRIPTION=WebView for JetBrains Compose Multiplatform

--- a/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WasmJsWebView.kt
+++ b/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WasmJsWebView.kt
@@ -176,7 +176,7 @@ class WasmJsWebView(
                 try {
                     val dataString = messageEvent.data.toString()
 
-                    if (dataString.contains("kmpJsBridge")) {
+                    if (dataString.contains(webViewJsBridge.jsBridgeName)) {
                         val actionPattern = """action[=:][\s]*['"](.*?)['"]""".toRegex()
                         val paramsPattern = """params[=:][\s]*['"](.*?)['"]""".toRegex()
                         val callbackPattern = """callbackId[=:][\s]*(\d+)""".toRegex()

--- a/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WebView.wasmJs.kt
+++ b/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WebView.wasmJs.kt
@@ -314,7 +314,7 @@ private fun setupJsBridgeForWasm(
             try {
                 val dataString = messageEvent.data.toString()
 
-                if (dataString.contains("kmpJsBridge") && dataString.startsWith("{")) {
+                if (dataString.contains(webViewJsBridge.jsBridgeName) && dataString.startsWith("{")) {
                     val actionPattern = """"action"\s*:\s*"([^"]*)"""".toRegex()
                     val paramsPattern = """"params"\s*:\s*"((?:[^"\\]|\\.)*)"""".toRegex()
                     val callbackPattern = """"callbackId"\s*:\s*(\d+)""".toRegex()

--- a/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WebViewJsBridge.kt
+++ b/webview/src/wasmJsMain/kotlin/com/multiplatform/webview/web/WebViewJsBridge.kt
@@ -19,7 +19,7 @@ internal fun createJsBridgeScript(
             postMessage: function(methodName, params, callbackId) {
                 // Send as JSON string instead of object to ensure proper parsing
                 var messageData = JSON.stringify({
-                    type: 'kmpJsBridge',
+                    type: '$jsBridgeName',
                     action: methodName,
                     params: params,
                     callbackId: callbackId || 0
@@ -55,7 +55,7 @@ internal fun createJsBridgeScript(
         window.addEventListener('message', function(event) {
             try {
                 var data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
-                if (data && data.type === 'kmpJsBridgeCallback') {
+                if (data && data.type === '$jsBridgeName') {
                     window.$jsBridgeName.onCallback(data.callbackId, data.message);
                 }
             } catch (e) {


### PR DESCRIPTION
This commit updates the WasmJs WebView implementation to use the `webViewJsBridge.jsBridgeName` property instead of the hardcoded "kmpJsBridge" string when identifying and processing messages from the JavaScript bridge. This allows for customization of the bridge name.

**WasmJs:**
- In `WasmJsWebView.kt` and `WebView.wasmJs.kt`, message handling logic now checks for `webViewJsBridge.jsBridgeName` in the incoming `dataString`.
- In `WebViewJsBridge.kt`, the injected JavaScript code for `postMessage` and the event listener now uses the dynamic `jsBridgeName` property for the `type` field in messages.

**Build:**
- Incremented `VERSION_NAME` to `2.0.3`.